### PR TITLE
Bugfix/0.1.3

### DIFF
--- a/ROCrates.Net.Tests/TestDataset.cs
+++ b/ROCrates.Net.Tests/TestDataset.cs
@@ -6,128 +6,143 @@ namespace ROCrates.Tests;
 
 public class TestDataset : IClassFixture<TestDatasetFixture>
 {
-  private TestDatasetFixture _testDatasetFixture;
-  private const string _testDirName = "my-test-dir/";
-  private readonly string _testFileJsonFile = "Fixtures/test-dataset.json";
+    private const string _testDirName = "my-test-dir/";
+    private readonly string _testFileJsonFile = "Fixtures/test-dataset.json";
+    private TestDatasetFixture _testDatasetFixture;
 
-  public TestDataset(TestDatasetFixture testDatasetFixture)
-  {
-    _testDatasetFixture = testDatasetFixture;
-  }
+    public TestDataset(TestDatasetFixture testDatasetFixture)
+    {
+        _testDatasetFixture = testDatasetFixture;
+    }
 
-  [Fact]
-  public void TestWrite_Creates_Dir_From_Source()
-  {
-    // Arrange
-    var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
-    Directory.CreateDirectory(sourceDir);
-    var dataset = new Models.Dataset(
-      new ROCrate(),
-      source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName));
+    [Fact]
+    public void TestWrite_Creates_Dir_From_Source()
+    {
+        // Arrange
+        var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
+        Directory.CreateDirectory(sourceDir);
+        var dataset = new Models.Dataset(
+            new ROCrate(),
+            source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName));
 
-    // Act
-    dataset.Write(_testDatasetFixture.TestBasePath);
+        // Act
+        dataset.Write(_testDatasetFixture.TestBasePath);
 
-    // Assert
-    Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, sourceDir)));
-  }
+        // Assert
+        Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, sourceDir)));
+    }
 
-  [Fact]
-  public void TestWrite_Creates_Dir_From_DestPath()
-  {
-    // Arrange
-    var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
-    var destPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
-    Directory.CreateDirectory(sourceDir);
-    Directory.CreateDirectory(destPath);
-    var dataset = new Models.Dataset(
-      new ROCrate(),
-      source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName),
-      destPath: destPath);
+    [Fact]
+    public void TestWrite_Creates_Dir_From_DestPath()
+    {
+        // Arrange
+        var sourceDir = Path.Combine(_testDatasetFixture.TestBasePath, _testDirName);
+        var destPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(destPath);
+        var dataset = new Models.Dataset(
+            new ROCrate(),
+            source: Path.Combine(_testDatasetFixture.TestBasePath, _testDirName),
+            destPath: destPath);
 
-    // Act
-    dataset.Write(_testDatasetFixture.TestBasePath);
+        // Act
+        dataset.Write(_testDatasetFixture.TestBasePath);
 
-    // Assert
-    Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, destPath)));
-  }
+        // Assert
+        Assert.True(Directory.Exists(Path.Combine(_testDatasetFixture.TestBasePath, destPath)));
+    }
 
-  [Fact]
-  public void TestWrite_Throws_When_SourceDir_DoesNotExist()
-  {
-    // Arrange
-    var testDestPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
-    Directory.CreateDirectory(testDestPath);
-    var dataset = new Models.Dataset(
-      new ROCrate(),
-      source: Path.Combine("non", "existent"),
-      destPath: testDestPath);
+    [Fact]
+    public void TestWrite_Throws_When_SourceDir_DoesNotExist()
+    {
+        // Arrange
+        var testDestPath = Path.Combine(_testDatasetFixture.TestBasePath, "ext", _testDirName);
+        Directory.CreateDirectory(testDestPath);
+        var dataset = new Models.Dataset(
+            new ROCrate(),
+            source: Path.Combine("non", "existent"),
+            destPath: testDestPath);
 
-    // Act
-    var throwingFunc = () => dataset.Write(_testDatasetFixture.TestBasePath);
+        // Act
+        var throwingFunc = () => dataset.Write(_testDatasetFixture.TestBasePath);
 
-    // Assert
-    Assert.Throws<DirectoryNotFoundException>(throwingFunc);
-  }
+        // Assert
+        Assert.Throws<DirectoryNotFoundException>(throwingFunc);
+    }
 
-  [Fact]
-  public void TestDataset_Serialises_Correctly()
-  {
-    // Arrange
-    var expectedJson = File.ReadAllText(_testFileJsonFile).TrimEnd();
-    var jsonObject = JsonNode.Parse(expectedJson).AsObject();
+    [Fact]
+    public void TestDataset_Serialises_Correctly()
+    {
+        // Arrange
+        var expectedJson = File.ReadAllText(_testFileJsonFile).TrimEnd();
+        var jsonObject = JsonNode.Parse(expectedJson).AsObject();
 
-    var dataset = new Models.Dataset(
-      new ROCrate(),
-      properties: jsonObject);
+        var dataset = new Models.Dataset(
+            new ROCrate(),
+            properties: jsonObject);
 
-    // Act
-    var actualJson = dataset.Serialize();
+        // Act
+        var actualJson = dataset.Serialize();
 
-    // Assert
-    Assert.Equal(expectedJson, actualJson);
-  }
+        // Assert
+        Assert.Equal(expectedJson, actualJson);
+    }
 
-  [Fact]
-  public void DatasetIdTag_Is_UnixPath()
-  {
-    // Arrange
-    var datasetSource = _testDatasetFixture.TestBasePath.Replace("/", "\\");
-    var expected = _testDatasetFixture.TestBasePath + '/';
+    [Fact]
+    public void DatasetIdTag_Is_UnixPath()
+    {
+        // Arrange
+        var datasetSource = _testDatasetFixture.TestBasePath.Replace("/", "\\");
+        var expected = _testDatasetFixture.TestBasePath + '/';
 
-    // Act
-    var dataset = new Dataset(source: datasetSource);
+        // Act
+        var dataset = new Dataset(source: datasetSource);
 
-    // Assert
-    Assert.Equal(expected, dataset.Id);
-  }
+        // Assert
+        Assert.Equal(expected, dataset.Id);
+    }
 
-  [Fact]
-  public void DatasetIdTag_Ends_WithSlash()
-  {
-    // Arrange
-    var datasetSource = _testDatasetFixture.TestBasePath;
-    var expected = _testDatasetFixture.TestBasePath + '/';
+    [Fact]
+    public void DatasetIdTag_Ends_WithSlash()
+    {
+        // Arrange
+        var datasetSource = _testDatasetFixture.TestBasePath;
+        var expected = _testDatasetFixture.TestBasePath + '/';
 
-    // Act
-    var dataset = new Dataset(source: datasetSource);
+        // Act
+        var dataset = new Dataset(source: datasetSource);
 
-    // Assert
-    Assert.Equal(expected, dataset.Id);
-  }
+        // Assert
+        Assert.Equal(expected, dataset.Id);
+    }
+
+    [Fact]
+    public void DatasetIdTag_Ends_WithoutSlashForRemoteSources()
+    {
+        // Arrange
+        var datasetSource = _testDatasetFixture.TestRemotePath;
+        var expected = _testDatasetFixture.TestRemotePath;
+
+        // Act
+        var dataset = new Dataset(source: datasetSource);
+
+        // Assert
+        Assert.Equal(expected, dataset.Id);
+    }
 }
 
 public class TestDatasetFixture : IDisposable
 {
-  public readonly string TestBasePath = Path.Combine("dataset", "test", "path");
+    public readonly string TestBasePath = Path.Combine("dataset", "test", "path");
+    public readonly string TestRemotePath = "https://workflowhub.eu/workflows/471?version=1";
 
-  public TestDatasetFixture()
-  {
-    Directory.CreateDirectory(TestBasePath);
-  }
+    public TestDatasetFixture()
+    {
+        Directory.CreateDirectory(TestBasePath);
+    }
 
-  public void Dispose()
-  {
-    Directory.Delete(TestBasePath, recursive: true);
-  }
+    public void Dispose()
+    {
+        Directory.Delete(TestBasePath, recursive: true);
+    }
 }

--- a/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/ROCrates.Net.Tests/TestRoCrate.cs
@@ -107,6 +107,33 @@ public class TestRoCrate
     }
 
     [Fact]
+    public void Save_Saves_DatasetsFirst()
+    {
+        // Arrange
+        var roCrate = new ROCrate();
+        var dirInfo = new DirectoryInfo(Guid.NewGuid().ToString());
+        dirInfo.Create();
+        var fileInfo = new FileInfo(Path.Combine(dirInfo.FullName, Guid.NewGuid().ToString()));
+        fileInfo.Create().Close();
+
+        var file = new File(crate: roCrate, source: fileInfo.FullName);
+        var dataset = new Dataset(crate: roCrate, source: dirInfo.FullName);
+
+        roCrate.Add(file, dataset);
+
+        // Act
+        roCrate.Save();
+
+        // Assert
+        Assert.True(dirInfo.Exists);
+        Assert.True(fileInfo.Exists);
+
+        // Clean up
+        if (fileInfo.Exists) fileInfo.Delete();
+        if (dirInfo.Exists) dirInfo.Delete(recursive: true);
+    }
+
+    [Fact]
     public void Initialise_Throws_WithNoMetadataJsonFile()
     {
         // Arrange

--- a/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/ROCrates.Net.Tests/TestRoCrate.cs
@@ -7,21 +7,6 @@ namespace ROCrates.Tests;
 public class TestRoCrate
 {
     [Fact]
-    public void ResolveId_Combines_GoodAndBad_Uris()
-    {
-        string validUrl = "https://doi.org/10.4225/59/59672c09f4a4b";
-        string invalidUrl = "https://do i.org/10.4225/59/59672c09f4a4b";
-        var crate = new ROCrate();
-
-        string resultValidUrl = crate.ResolveId(validUrl);
-        Assert.Equal(validUrl, resultValidUrl);
-
-        string resultInvalidUrl = crate.ResolveId(invalidUrl);
-        Assert.StartsWith("arcp://", resultInvalidUrl);
-        Assert.EndsWith(invalidUrl, resultInvalidUrl);
-    }
-
-    [Fact]
     public void Add_Adds_ObjetsOfDifferentTypes()
     {
         var roCrate = new ROCrate();
@@ -31,16 +16,16 @@ public class TestRoCrate
 
         roCrate.Add(person, file, dataset);
 
-        Assert.True(roCrate.Entities.ContainsKey(person.GetCanonicalId()));
-        Assert.True(roCrate.Entities.TryGetValue(person.GetCanonicalId(), out var recoveredPerson));
+        Assert.True(roCrate.Entities.ContainsKey(person.Id));
+        Assert.True(roCrate.Entities.TryGetValue(person.Id, out var recoveredPerson));
         Assert.IsType<Person>(recoveredPerson);
 
-        Assert.True(roCrate.Entities.ContainsKey(file.GetCanonicalId()));
-        Assert.True(roCrate.Entities.TryGetValue(file.GetCanonicalId(), out var recoveredFile));
+        Assert.True(roCrate.Entities.ContainsKey(file.Id));
+        Assert.True(roCrate.Entities.TryGetValue(file.Id, out var recoveredFile));
         Assert.IsType<File>(recoveredFile);
 
-        Assert.True(roCrate.Entities.ContainsKey(dataset.GetCanonicalId()));
-        Assert.True(roCrate.Entities.TryGetValue(dataset.GetCanonicalId(), out var recoveredDataset));
+        Assert.True(roCrate.Entities.ContainsKey(dataset.Id));
+        Assert.True(roCrate.Entities.TryGetValue(dataset.Id, out var recoveredDataset));
         Assert.IsType<Dataset>(recoveredDataset);
     }
 

--- a/ROCrates.Net.Tests/TestRoCrate.cs
+++ b/ROCrates.Net.Tests/TestRoCrate.cs
@@ -6,320 +6,340 @@ namespace ROCrates.Tests;
 
 public class TestRoCrate
 {
-  [Fact]
-  public void ResolveId_Combines_GoodAndBad_Uris()
-  {
-    string validUrl = "https://doi.org/10.4225/59/59672c09f4a4b";
-    string invalidUrl = "https://do i.org/10.4225/59/59672c09f4a4b";
-    var crate = new ROCrate();
-
-    string resultValidUrl = crate.ResolveId(validUrl);
-    Assert.Equal(validUrl, resultValidUrl);
-
-    string resultInvalidUrl = crate.ResolveId(invalidUrl);
-    Assert.StartsWith("arcp://", resultInvalidUrl);
-    Assert.EndsWith(invalidUrl, resultInvalidUrl);
-  }
-
-  [Fact]
-  public void Add_Adds_ObjetsOfDifferentTypes()
-  {
-    var roCrate = new ROCrate();
-    var person = new Person(roCrate);
-    var file = new File(roCrate, source: "my-test-file.txt");
-    var dataset = new Dataset(roCrate, source: "my-data-dir/");
-
-    roCrate.Add(person, file, dataset);
-
-    Assert.True(roCrate.Entities.ContainsKey(person.GetCanonicalId()));
-    Assert.True(roCrate.Entities.TryGetValue(person.GetCanonicalId(), out var recoveredPerson));
-    Assert.IsType<Person>(recoveredPerson);
-
-    Assert.True(roCrate.Entities.ContainsKey(file.GetCanonicalId()));
-    Assert.True(roCrate.Entities.TryGetValue(file.GetCanonicalId(), out var recoveredFile));
-    Assert.IsType<File>(recoveredFile);
-
-    Assert.True(roCrate.Entities.ContainsKey(dataset.GetCanonicalId()));
-    Assert.True(roCrate.Entities.TryGetValue(dataset.GetCanonicalId(), out var recoveredDataset));
-    Assert.IsType<Dataset>(recoveredDataset);
-  }
-
-  [Fact]
-  public void Save_Creates_DirectoryWithFiles()
-  {
-    // Arrange
-    var file1 = new FileInfo(Guid.NewGuid().ToString());
-    file1.Create().Close();
-    var file2 = new FileInfo(Guid.NewGuid().ToString());
-    file2.Create().Close();
-    var outputDir = Guid.NewGuid().ToString();
-
-    var roCrate = new ROCrate();
-    var fileObject1 = new File(crate: roCrate, source: file1.ToString());
-    var fileObject2 = new File(crate: roCrate, source: file2.ToString());
-    roCrate.Add(fileObject1, fileObject2);
-
-    // Act
-    roCrate.Save(outputDir);
-
-    // Assert
-    Assert.True(System.IO.File.Exists(Path.Combine(outputDir, file1.Name)));
-    Assert.True(System.IO.File.Exists(Path.Combine(outputDir, file2.Name)));
-
-    // Clean up
-    if (file1.Exists) file1.Delete();
-    if (file2.Exists) file2.Delete();
-    if (Directory.Exists(outputDir)) Directory.Delete(outputDir, recursive: true);
-  }
-
-  [Fact]
-  public void Save_Creates_ZipWithFiles()
-  {
-    // Arrange
-    var file1 = new FileInfo(Guid.NewGuid().ToString());
-    file1.Create().Close();
-    var file2 = new FileInfo(Guid.NewGuid().ToString());
-    file2.Create().Close();
-    var outputDir = Guid.NewGuid().ToString();
-    var outputZipFile = $"{outputDir}.zip";
-
-    var roCrate = new ROCrate();
-    var fileObject1 = new File(crate: roCrate, source: file1.ToString());
-    var fileObject2 = new File(crate: roCrate, source: file2.ToString());
-    roCrate.Add(fileObject1, fileObject2);
-
-    // Act
-    roCrate.Save(outputDir, zip: true);
-
-    // Assert
-    Assert.True(System.IO.File.Exists(outputZipFile));
-
-    // Clean up
-    if (file1.Exists) file1.Delete();
-    if (file2.Exists) file2.Delete();
-    if (Directory.Exists(outputDir)) Directory.Delete(outputDir, recursive: true);
-    if (System.IO.File.Exists(outputZipFile)) System.IO.File.Delete(outputZipFile);
-  }
-
-  [Fact]
-  public void Initialise_Throws_WithNoMetadataJsonFile()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    var roCrate = new ROCrate();
-
-    // Act
-    var action = () => roCrate.Initialise(testDir.FullName);
-
-    // Assert
-    Assert.Throws<CrateReadException>(action);
-
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
-
-  [Fact]
-  public void Initialise_Throws_WhenSourceNonExistent()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    var roCrate = new ROCrate();
-
-    // Act
-    var action = () => roCrate.Initialise(testDir.FullName);
-
-    // Assert
-    Assert.Throws<CrateReadException>(action);
-  }
-
-  [Fact]
-  public void Initialise_Throws_WhenSourceIsNotADirectory()
-  {
-    // Arrange
-    var testFile = new FileInfo(Guid.NewGuid().ToString());
-    testFile.Create();
-    var roCrate = new ROCrate();
-
-    // Act
-    var action = () => roCrate.Initialise(testFile.FullName);
-
-    // Assert
-    Assert.Throws<CrateReadException>(action);
-
-    // Clean up
-    if (testFile.Exists) testFile.Delete();
-  }
-
-  [Fact]
-  public void Initialise_Throws_WhenMetadataIsEmpty()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    var testFile = new FileInfo(Path.Combine(testDir.FullName, "ro-crate-metadata.json"));
-    testFile.Create().Close();
-    var roCrate = new ROCrate();
-
-    // Act
-    var action = () => roCrate.Initialise(testDir.FullName);
-
-    // Assert
-    Assert.Throws<MetadataException>(action);
-
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
-
-  [Fact]
-  public void Initialise_Throws_WhenMetadataMissingContentAndGraph()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    var testFile = new FileInfo(Path.Combine(testDir.FullName, "ro-crate-metadata.json"));
-    using (var s = testFile.CreateText())
+    [Fact]
+    public void ResolveId_Combines_GoodAndBad_Uris()
     {
-      s.Write("{}");
+        string validUrl = "https://doi.org/10.4225/59/59672c09f4a4b";
+        string invalidUrl = "https://do i.org/10.4225/59/59672c09f4a4b";
+        var crate = new ROCrate();
+
+        string resultValidUrl = crate.ResolveId(validUrl);
+        Assert.Equal(validUrl, resultValidUrl);
+
+        string resultInvalidUrl = crate.ResolveId(invalidUrl);
+        Assert.StartsWith("arcp://", resultInvalidUrl);
+        Assert.EndsWith(invalidUrl, resultInvalidUrl);
     }
 
-    var roCrate = new ROCrate();
+    [Fact]
+    public void Add_Adds_ObjetsOfDifferentTypes()
+    {
+        var roCrate = new ROCrate();
+        var person = new Person(roCrate);
+        var file = new File(roCrate, source: "my-test-file.txt");
+        var dataset = new Dataset(roCrate, source: "my-data-dir/");
 
-    // Act
-    var action = () => roCrate.Initialise(testDir.FullName);
+        roCrate.Add(person, file, dataset);
 
-    // Assert
-    Assert.Throws<MetadataException>(action);
+        Assert.True(roCrate.Entities.ContainsKey(person.GetCanonicalId()));
+        Assert.True(roCrate.Entities.TryGetValue(person.GetCanonicalId(), out var recoveredPerson));
+        Assert.IsType<Person>(recoveredPerson);
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        Assert.True(roCrate.Entities.ContainsKey(file.GetCanonicalId()));
+        Assert.True(roCrate.Entities.TryGetValue(file.GetCanonicalId(), out var recoveredFile));
+        Assert.IsType<File>(recoveredFile);
 
-  [Fact]
-  public void Initialise_Throws_WhenGraphElementIsInvalid()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    System.IO.File.Copy(
-      "Fixtures/test-invalid-metadata.json",
-      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
-    );
-    var roCrate = new ROCrate();
+        Assert.True(roCrate.Entities.ContainsKey(dataset.GetCanonicalId()));
+        Assert.True(roCrate.Entities.TryGetValue(dataset.GetCanonicalId(), out var recoveredDataset));
+        Assert.IsType<Dataset>(recoveredDataset);
+    }
 
-    // Act
-    var action = () => roCrate.Initialise(testDir.FullName);
+    [Fact]
+    public void Add_Updates_EntitiesWithSameName()
+    {
+        // Arrange
+        var roCrate = new ROCrate();
+        var (testKey, testValue) = ("key", "value");
+        var file1 = new File(crate: roCrate, source: "file.txt");
+        roCrate.Add(file1);
+        var file2 = new File(crate: roCrate, source: file1.Id);
+        file2.SetProperty(testKey, testValue);
 
-    // Assert
-    Assert.Throws<MetadataException>(action);
+        // Act
+        roCrate.Add(file2);
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        // Assert
+        Assert.Equal(file1.Id, file2.Id);
+        Assert.Contains(file1.Id, roCrate.Entities.Keys);
+        Assert.Contains(testKey, roCrate.Entities[file1.Id].Properties);
+    }
 
-  [Fact]
-  public void Initialise_Reads_EntitiesToROCrateObject()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    System.IO.File.Copy(
-      "Fixtures/metadata-test.json",
-      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
-    );
-    var roCrate = new ROCrate();
+    [Fact]
+    public void Save_Creates_DirectoryWithFiles()
+    {
+        // Arrange
+        var file1 = new FileInfo(Guid.NewGuid().ToString());
+        file1.Create().Close();
+        var file2 = new FileInfo(Guid.NewGuid().ToString());
+        file2.Create().Close();
+        var outputDir = Guid.NewGuid().ToString();
 
-    // Act
-    roCrate.Initialise(testDir.FullName);
+        var roCrate = new ROCrate();
+        var fileObject1 = new File(crate: roCrate, source: file1.ToString());
+        var fileObject2 = new File(crate: roCrate, source: file2.ToString());
+        roCrate.Add(fileObject1, fileObject2);
 
-    // Assert
-    Assert.Contains("./", roCrate.Entities.Keys);
-    Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
-    Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
-    Assert.Contains("cp7glop.ai", roCrate.Entities.Keys);
-    Assert.Contains("lots_of_little_files/", roCrate.Entities.Keys);
+        // Act
+        roCrate.Save(outputDir);
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        // Assert
+        Assert.True(System.IO.File.Exists(Path.Combine(outputDir, file1.Name)));
+        Assert.True(System.IO.File.Exists(Path.Combine(outputDir, file2.Name)));
 
-  [Fact]
-  public void Initialise_Reads_ObjectsWithCompoundTypes()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    System.IO.File.Copy(
-      "Fixtures/test-compound-types.json",
-      Path.Combine(testDir.FullName, "ro-crate-metadata.json")
-    );
-    var roCrate = new ROCrate();
+        // Clean up
+        if (file1.Exists) file1.Delete();
+        if (file2.Exists) file2.Delete();
+        if (Directory.Exists(outputDir)) Directory.Delete(outputDir, recursive: true);
+    }
 
-    // Act
-    roCrate.Initialise(testDir.FullName);
+    [Fact]
+    public void Save_Creates_ZipWithFiles()
+    {
+        // Arrange
+        var file1 = new FileInfo(Guid.NewGuid().ToString());
+        file1.Create().Close();
+        var file2 = new FileInfo(Guid.NewGuid().ToString());
+        file2.Create().Close();
+        var outputDir = Guid.NewGuid().ToString();
+        var outputZipFile = $"{outputDir}.zip";
 
-    // Assert
-    Assert.Contains("./", roCrate.Entities.Keys);
-    Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
-    Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
-    Assert.Contains("alignment.knime", roCrate.Entities.Keys);
+        var roCrate = new ROCrate();
+        var fileObject1 = new File(crate: roCrate, source: file1.ToString());
+        var fileObject2 = new File(crate: roCrate, source: file2.ToString());
+        roCrate.Add(fileObject1, fileObject2);
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        // Act
+        roCrate.Save(outputDir, zip: true);
 
-  [Fact]
-  public void Convert_Creates_PreviewAndMetadata()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    var roCrate = new ROCrate();
+        // Assert
+        Assert.True(System.IO.File.Exists(outputZipFile));
 
-    // Act
-    roCrate.Convert(testDir.FullName);
+        // Clean up
+        if (file1.Exists) file1.Delete();
+        if (file2.Exists) file2.Delete();
+        if (Directory.Exists(outputDir)) Directory.Delete(outputDir, recursive: true);
+        if (System.IO.File.Exists(outputZipFile)) System.IO.File.Delete(outputZipFile);
+    }
 
-    // Assert
-    Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Metadata.Id)));
-    Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Preview.Id)));
+    [Fact]
+    public void Initialise_Throws_WithNoMetadataJsonFile()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        var roCrate = new ROCrate();
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        // Act
+        var action = () => roCrate.Initialise(testDir.FullName);
 
-  [Fact]
-  public void Convert_Creates_ROCrateWithAllEntities()
-  {
-    // Arrange
-    var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
-    testDir.Create();
-    var subDir = testDir.CreateSubdirectory(Guid.NewGuid().ToString());
-    var topLevelFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
-    topLevelFile.Create().Close();
-    topLevelFile.MoveTo(Path.Combine(testDir.FullName, topLevelFile.Name));
-    var subDirFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
-    subDirFile.Create().Close();
-    subDirFile.MoveTo(Path.Combine(subDir.FullName, subDirFile.Name));
-    var roCrate = new ROCrate();
+        // Assert
+        Assert.Throws<CrateReadException>(action);
 
-    // Act
-    roCrate.Convert(testDir.FullName);
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
 
-    // Assert
-    Assert.Contains(
-      Path.GetRelativePath(testDir.FullName, topLevelFile.FullName),
-      roCrate.Entities.Keys
-    );
-    Assert.Contains(
-      Path.GetRelativePath(testDir.FullName, subDir.FullName) + "/",
-      roCrate.Entities.Keys
-    );
-    Assert.Contains(
-      Path.GetRelativePath(testDir.FullName, subDirFile.FullName),
-      roCrate.Entities.Keys
-    );
+    [Fact]
+    public void Initialise_Throws_WhenSourceNonExistent()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        var roCrate = new ROCrate();
 
-    // Clean up
-    if (testDir.Exists) testDir.Delete(recursive: true);
-  }
+        // Act
+        var action = () => roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Throws<CrateReadException>(action);
+    }
+
+    [Fact]
+    public void Initialise_Throws_WhenSourceIsNotADirectory()
+    {
+        // Arrange
+        var testFile = new FileInfo(Guid.NewGuid().ToString());
+        testFile.Create();
+        var roCrate = new ROCrate();
+
+        // Act
+        var action = () => roCrate.Initialise(testFile.FullName);
+
+        // Assert
+        Assert.Throws<CrateReadException>(action);
+
+        // Clean up
+        if (testFile.Exists) testFile.Delete();
+    }
+
+    [Fact]
+    public void Initialise_Throws_WhenMetadataIsEmpty()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        var testFile = new FileInfo(Path.Combine(testDir.FullName, "ro-crate-metadata.json"));
+        testFile.Create().Close();
+        var roCrate = new ROCrate();
+
+        // Act
+        var action = () => roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Throws<MetadataException>(action);
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Initialise_Throws_WhenMetadataMissingContentAndGraph()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        var testFile = new FileInfo(Path.Combine(testDir.FullName, "ro-crate-metadata.json"));
+        using (var s = testFile.CreateText())
+        {
+            s.Write("{}");
+        }
+
+        var roCrate = new ROCrate();
+
+        // Act
+        var action = () => roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Throws<MetadataException>(action);
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Initialise_Throws_WhenGraphElementIsInvalid()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        System.IO.File.Copy(
+            "Fixtures/test-invalid-metadata.json",
+            Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+        );
+        var roCrate = new ROCrate();
+
+        // Act
+        var action = () => roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Throws<MetadataException>(action);
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Initialise_Reads_EntitiesToROCrateObject()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        System.IO.File.Copy(
+            "Fixtures/metadata-test.json",
+            Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+        );
+        var roCrate = new ROCrate();
+
+        // Act
+        roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Contains("./", roCrate.Entities.Keys);
+        Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
+        Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
+        Assert.Contains("cp7glop.ai", roCrate.Entities.Keys);
+        Assert.Contains("lots_of_little_files/", roCrate.Entities.Keys);
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Initialise_Reads_ObjectsWithCompoundTypes()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        System.IO.File.Copy(
+            "Fixtures/test-compound-types.json",
+            Path.Combine(testDir.FullName, "ro-crate-metadata.json")
+        );
+        var roCrate = new ROCrate();
+
+        // Act
+        roCrate.Initialise(testDir.FullName);
+
+        // Assert
+        Assert.Contains("./", roCrate.Entities.Keys);
+        Assert.Contains("ro-crate-metadata.json", roCrate.Entities.Keys);
+        Assert.Contains("ro-crate-preview.html", roCrate.Entities.Keys);
+        Assert.Contains("alignment.knime", roCrate.Entities.Keys);
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Convert_Creates_PreviewAndMetadata()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        var roCrate = new ROCrate();
+
+        // Act
+        roCrate.Convert(testDir.FullName);
+
+        // Assert
+        Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Metadata.Id)));
+        Assert.True(System.IO.File.Exists(Path.Combine(testDir.FullName, roCrate.Preview.Id)));
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
+
+    [Fact]
+    public void Convert_Creates_ROCrateWithAllEntities()
+    {
+        // Arrange
+        var testDir = new DirectoryInfo(Guid.NewGuid().ToString());
+        testDir.Create();
+        var subDir = testDir.CreateSubdirectory(Guid.NewGuid().ToString());
+        var topLevelFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
+        topLevelFile.Create().Close();
+        topLevelFile.MoveTo(Path.Combine(testDir.FullName, topLevelFile.Name));
+        var subDirFile = new FileInfo($"{Guid.NewGuid().ToString()}.json");
+        subDirFile.Create().Close();
+        subDirFile.MoveTo(Path.Combine(subDir.FullName, subDirFile.Name));
+        var roCrate = new ROCrate();
+
+        // Act
+        roCrate.Convert(testDir.FullName);
+
+        // Assert
+        Assert.Contains(
+            Path.GetRelativePath(testDir.FullName, topLevelFile.FullName),
+            roCrate.Entities.Keys
+        );
+        Assert.Contains(
+            Path.GetRelativePath(testDir.FullName, subDir.FullName) + "/",
+            roCrate.Entities.Keys
+        );
+        Assert.Contains(
+            Path.GetRelativePath(testDir.FullName, subDirFile.FullName),
+            roCrate.Entities.Keys
+        );
+
+        // Clean up
+        if (testDir.Exists) testDir.Delete(recursive: true);
+    }
 }

--- a/ROCrates.Net/Models/ContextEntity.cs
+++ b/ROCrates.Net/Models/ContextEntity.cs
@@ -7,58 +7,58 @@ namespace ROCrates.Models;
 
 public class ContextEntity : Entity
 {
-  public ContextEntity(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null) : base(crate,
-    identifier, properties)
-  {
-    Id = _formatIdentifier(Id);
-    if (properties is not null) _unpackProperties(properties);
-  }
-
-  public ContextEntity()
-  {
-    Id = _formatIdentifier(Id);
-  }
-
-  private protected sealed override string _formatIdentifier(string identifier)
-  {
-    if (Uri.IsWellFormedUriString(identifier, UriKind.RelativeOrAbsolute) || identifier.Contains('#'))
-      return identifier;
-
-    return "#" + identifier;
-  }
-
-  /// <summary>
-  /// Convert <see cref="ContextEntity"/> to JSON string.
-  /// </summary>
-  /// <returns>The <see cref="ContextEntity"/> as a JSON string.</returns>
-  public override string Serialize()
-  {
-    var options = new JsonSerializerOptions
+    public ContextEntity(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null) : base(crate,
+        identifier, properties)
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<ContextEntity>() }
-    };
-    var serialised = JsonSerializer.Serialize(this, options);
-    return serialised;
-  }
+        Id = _formatIdentifier(Id);
+        if (properties is not null) _unpackProperties(properties);
+    }
 
-  /// <summary>
-  /// Create a <see cref="ContextEntity"/> from JSON properties.
-  /// </summary>
-  /// <param name="entityJson">The JSON representing the <see cref="ContextEntity"/></param>
-  /// <param name="roCrate">The RO-Crate for the <see cref="ContextEntity"/></param>
-  /// <returns>The deserialised <see cref="ContextEntity"/></returns>
-  public new static ContextEntity? Deserialize(string entityJson, ROCrate roCrate)
-  {
-    var options = new JsonSerializerOptions
+    public ContextEntity()
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<ContextEntity>() }
-    };
-    var deserialized = JsonSerializer.Deserialize<ContextEntity>(entityJson, options);
-    if (deserialized is not null) deserialized.RoCrate = roCrate;
-    return deserialized;
-  }
+        Id = _formatIdentifier(Id);
+    }
+
+    private protected sealed override string _formatIdentifier(string identifier)
+    {
+        if (Uri.IsWellFormedUriString(identifier, UriKind.RelativeOrAbsolute) || identifier.StartsWith('#'))
+            return identifier;
+
+        return "#" + identifier;
+    }
+
+    /// <summary>
+    /// Convert <see cref="ContextEntity"/> to JSON string.
+    /// </summary>
+    /// <returns>The <see cref="ContextEntity"/> as a JSON string.</returns>
+    public override string Serialize()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<ContextEntity>() }
+        };
+        var serialised = JsonSerializer.Serialize(this, options);
+        return serialised;
+    }
+
+    /// <summary>
+    /// Create a <see cref="ContextEntity"/> from JSON properties.
+    /// </summary>
+    /// <param name="entityJson">The JSON representing the <see cref="ContextEntity"/></param>
+    /// <param name="roCrate">The RO-Crate for the <see cref="ContextEntity"/></param>
+    /// <returns>The deserialised <see cref="ContextEntity"/></returns>
+    public new static ContextEntity? Deserialize(string entityJson, ROCrate roCrate)
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<ContextEntity>() }
+        };
+        var deserialized = JsonSerializer.Deserialize<ContextEntity>(entityJson, options);
+        if (deserialized is not null) deserialized.RoCrate = roCrate;
+        return deserialized;
+    }
 }

--- a/ROCrates.Net/Models/Dataset.cs
+++ b/ROCrates.Net/Models/Dataset.cs
@@ -8,143 +8,148 @@ namespace ROCrates.Models;
 
 public class Dataset : FileOrDir
 {
-  public Dataset(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null, string? source = null,
-    string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier, properties,
-    source, destPath, fetchRemote, validateUrl)
-  {
-    DefaultType = "Dataset";
-    Id = _formatIdentifier(Id);
-    Properties = _empty();
-    if (properties is not null) _unpackProperties(properties);
-  }
-
-  public Dataset()
-  {
-    DefaultType = "Dataset";
-    Id = _formatIdentifier(Id);
-    Properties = _empty();
-  }
-
-  /// <summary>
-  /// <para>Write the contents of a <c>Dataset</c> to disk.</para>
-  /// <para>If the <c>Dataset</c>'s source is remote, the contents will be downloaded to <c>basePath</c>.</para>
-  /// <para>If the source is on disk, the contents will be copied under <c>basePath</c>.</para>
-  /// </summary>
-  /// <example>
-  /// <code>
-  /// var url = "https://hdruk.github.io/hutch/docs/devs";
-  /// var dirName = url.Split('/').Last();
-  /// var dataset = new Models.Dataset(
-  ///    new ROCrate("myCrate.zip"),
-  ///    source: url,
-  ///    validateUrl: true,
-  ///    fetchRemote: true);
-  /// dataset.Write("myCrate");
-  /// Assert.True(Directory.Exists(Path.Combine("myCrate", dirName)));
-  /// </code>
-  /// </example>
-  /// <param name="basePath">The path under which the <c>Dataset</c>'s parts will be written.</param>
-  /// <exception cref="DirectoryNotFoundException">
-  /// Thrown when the source directory is not a URL, but it doesn't exist.
-  /// </exception>
-  public override void Write(string basePath)
-  {
-    var outPath = Path.Join(basePath, Id);
-    if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
+    public Dataset(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null,
+        string? source = null,
+        string? destPath = null, bool fetchRemote = false, bool validateUrl = false) : base(crate, identifier,
+        properties,
+        source, destPath, fetchRemote, validateUrl)
     {
-      if (_validateUrl && !_fetchRemote)
-      {
-        using HttpClient client = new HttpClient();
-        var response = client.GetAsync(_source).Result.Content;
-        SetProperty("sdDatePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
-      }
-
-      if (_fetchRemote)
-      {
-        _getParts(outPath);
-      }
-    }
-    else
-    {
-      if (!Directory.Exists(_source)) throw new DirectoryNotFoundException($"{_source} does not exist.");
-      Directory.CreateDirectory(outPath);
-    }
-  }
-
-  private void _getParts(string outPath)
-  {
-    Directory.CreateDirectory(outPath);
-    var basePath = _source.TrimEnd('/');
-    var parts = GetProperty<Dictionary<string, string>>("hasPart");
-    if (parts is null) return;
-    using var httpClient = new HttpClient();
-    foreach (var p in parts)
-    {
-      var part = p.Key == "@id" ? p.Value : null;
-      if (part is null) continue;
-      var partUri = $"{basePath}/{part}";
-      var partOutPath = Path.Combine(outPath, part);
-      var response = httpClient.GetAsync(partUri).Result.Content;
-      using var httpStream = response.ReadAsStream();
-      using var file = System.IO.File.OpenWrite(partOutPath);
-      httpStream.CopyTo(file);
-    }
-  }
-
-  protected new JsonObject _empty()
-  {
-    var emptyJsonString = new Dictionary<string, string>
-    {
-      { "@id", Id },
-      { "@type", DefaultType },
-      { "datePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }
-    };
-    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
-    return emptyObject;
-  }
-
-  private protected sealed override string _formatIdentifier(string identifier)
-  {
-    if (!identifier.EndsWith(Path.DirectorySeparatorChar) && !identifier.EndsWith(Path.AltDirectorySeparatorChar))
-    {
-      return identifier + Path.AltDirectorySeparatorChar;
+        DefaultType = "Dataset";
+        Id = _formatIdentifier(Id);
+        Properties = _empty();
+        if (properties is not null) _unpackProperties(properties);
     }
 
-    return identifier;
-  }
-
-  /// <summary>
-  /// Convert <see cref="Dataset"/> to JSON string.
-  /// </summary>
-  /// <returns>The <see cref="Dataset"/> as a JSON string.</returns>
-  public override string Serialize()
-  {
-    var options = new JsonSerializerOptions
+    public Dataset()
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<Dataset>() }
-    };
-    var serialised = JsonSerializer.Serialize(this, options);
-    return serialised;
-  }
+        DefaultType = "Dataset";
+        Id = _formatIdentifier(Id);
+        Properties = _empty();
+    }
 
-  /// <summary>
-  /// Create a <see cref="Dataset"/> from JSON properties.
-  /// </summary>
-  /// <param name="entityJson">The JSON representing the <see cref="Dataset"/></param>
-  /// <param name="roCrate">The RO-Crate for the <see cref="Dataset"/></param>
-  /// <returns>The deserialised <see cref="Dataset"/></returns>
-  public new static Dataset? Deserialize(string entityJson, ROCrate roCrate)
-  {
-    var options = new JsonSerializerOptions
+    /// <summary>
+    /// <para>Write the contents of a <c>Dataset</c> to disk.</para>
+    /// <para>If the <c>Dataset</c>'s source is remote, the contents will be downloaded to <c>basePath</c>.</para>
+    /// <para>If the source is on disk, the contents will be copied under <c>basePath</c>.</para>
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var url = "https://hdruk.github.io/hutch/docs/devs";
+    /// var dirName = url.Split('/').Last();
+    /// var dataset = new Models.Dataset(
+    ///    new ROCrate("myCrate.zip"),
+    ///    source: url,
+    ///    validateUrl: true,
+    ///    fetchRemote: true);
+    /// dataset.Write("myCrate");
+    /// Assert.True(Directory.Exists(Path.Combine("myCrate", dirName)));
+    /// </code>
+    /// </example>
+    /// <param name="basePath">The path under which the <c>Dataset</c>'s parts will be written.</param>
+    /// <exception cref="DirectoryNotFoundException">
+    /// Thrown when the source directory is not a URL, but it doesn't exist.
+    /// </exception>
+    public override void Write(string basePath)
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<Dataset>() }
-    };
-    var deserialized = JsonSerializer.Deserialize<Dataset>(entityJson, options);
-    if (deserialized is not null) deserialized.RoCrate = roCrate;
-    return deserialized;
-  }
+        var outPath = Path.Join(basePath, Id);
+        if (Uri.IsWellFormedUriString(_source, UriKind.Absolute))
+        {
+            if (_validateUrl && !_fetchRemote)
+            {
+                using HttpClient client = new HttpClient();
+                var response = client.GetAsync(_source).Result.Content;
+                SetProperty("sdDatePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (_fetchRemote)
+            {
+                _getParts(outPath);
+            }
+        }
+        else
+        {
+            if (!Directory.Exists(_source)) throw new DirectoryNotFoundException($"{_source} does not exist.");
+            Directory.CreateDirectory(outPath);
+        }
+    }
+
+    private void _getParts(string outPath)
+    {
+        Directory.CreateDirectory(outPath);
+        var basePath = _source.TrimEnd('/');
+        var parts = GetProperty<Dictionary<string, string>>("hasPart");
+        if (parts is null) return;
+        using var httpClient = new HttpClient();
+        foreach (var p in parts)
+        {
+            var part = p.Key == "@id" ? p.Value : null;
+            if (part is null) continue;
+            var partUri = $"{basePath}/{part}";
+            var partOutPath = Path.Combine(outPath, part);
+            var response = httpClient.GetAsync(partUri).Result.Content;
+            using var httpStream = response.ReadAsStream();
+            using var file = System.IO.File.OpenWrite(partOutPath);
+            httpStream.CopyTo(file);
+        }
+    }
+
+    protected new JsonObject _empty()
+    {
+        var emptyJsonString = new Dictionary<string, string>
+        {
+            { "@id", Id },
+            { "@type", DefaultType },
+            { "datePublished", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }
+        };
+        var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
+        return emptyObject;
+    }
+
+    private protected sealed override string _formatIdentifier(string identifier)
+    {
+        var uri = new Uri(identifier, UriKind.RelativeOrAbsolute);
+        identifier = identifier.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (uri.IsAbsoluteUri) return identifier;
+        if (!identifier.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            return identifier + Path.AltDirectorySeparatorChar;
+        }
+
+        return identifier;
+    }
+
+    /// <summary>
+    /// Convert <see cref="Dataset"/> to JSON string.
+    /// </summary>
+    /// <returns>The <see cref="Dataset"/> as a JSON string.</returns>
+    public override string Serialize()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<Dataset>() }
+        };
+        var serialised = JsonSerializer.Serialize(this, options);
+        return serialised;
+    }
+
+    /// <summary>
+    /// Create a <see cref="Dataset"/> from JSON properties.
+    /// </summary>
+    /// <param name="entityJson">The JSON representing the <see cref="Dataset"/></param>
+    /// <param name="roCrate">The RO-Crate for the <see cref="Dataset"/></param>
+    /// <returns>The deserialised <see cref="Dataset"/></returns>
+    public new static Dataset? Deserialize(string entityJson, ROCrate roCrate)
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<Dataset>() }
+        };
+        var deserialized = JsonSerializer.Deserialize<Dataset>(entityJson, options);
+        if (deserialized is not null) deserialized.RoCrate = roCrate;
+        return deserialized;
+    }
 }

--- a/ROCrates.Net/Models/Entity.cs
+++ b/ROCrates.Net/Models/Entity.cs
@@ -10,190 +10,191 @@ namespace ROCrates.Models;
 /// </summary>
 public class Entity
 {
-  private protected string DefaultType = "Thing";
+    private protected string DefaultType = "Thing";
 
-  public ROCrate? RoCrate { get; set; }
-
-  public string Id { get; set; }
-
-  public JsonObject Properties { get; set; }
-
-  public Entity()
-  {
-    Id = Guid.NewGuid().ToString();
-    Properties = _empty();
-  }
-
-  public Entity(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null)
-  {
-    RoCrate = crate;
-    Id = identifier ?? Guid.NewGuid().ToString();
-    Properties = _empty();
-    if (properties is not null) _unpackProperties(properties);
-  }
-
-  /// <summary>
-  /// Get the canonical ID of the crate that the entity is in.
-  /// </summary>
-  /// <returns></returns>
-  public string GetCanonicalId()
-  {
-    return RoCrate.ResolveId(Id);
-  }
-
-  /// <summary>
-  /// Retrieve a property from <c>Properties</c> deserialsed as type <c>T</c>.
-  /// </summary>
-  /// <param name="propertyName">The name of the property to retrieve.</param>
-  /// <typeparam name="T">The type to deserialise the property into.</typeparam>
-  /// <returns>
-  /// <para>
-  /// The property as type <c>T</c> if the property exists, or <c>null</c> if the property does no exist on the entity.
-  /// </para>T
-  /// </returns>
-  public T? GetProperty<T>(string propertyName)
-  {
-    Properties.TryGetPropertyValue(propertyName, out var property);
-    var deserialisedProperty = property.Deserialize<T>();
-    return deserialisedProperty;
-  }
-
-  /// <summary>
-  /// Sersialise a property into the <c>Properties</c> field. This will update a property if it already exists.
-  /// </summary>
-  /// <param name="propertyName"></param>
-  /// <param name="property"></param>
-  /// <typeparam name="T"></typeparam>
-  public void SetProperty<T>(string propertyName, T property)
-  {
-    var serialisedProperty = JsonSerializer.SerializeToNode(property);
-    if (serialisedProperty != null)
+    public Entity()
     {
-      // If a property already exists, remove first to avoid an exception, then add the new property
-      if (Properties.Remove(propertyName))
-      {
-        Properties.Add(propertyName, serialisedProperty);
-      }
-      else
-      {
-        Properties.Add(propertyName, serialisedProperty);
-      }
-    }
-  }
-
-  /// <summary>
-  /// Append a value to the entity's property.
-  /// </summary>
-  /// <param name="key">The element to append the value to.</param>
-  /// <param name="value">The value to be appended.</param>
-  /// <typeparam name="T">The type of <c>Entity</c> to be appended.</typeparam>
-  /// <exception cref="Exception">
-  /// Thrown when attempting to append to reserved key (those starting with '@').
-  /// </exception>
-  /// <exception cref="NullReferenceException">Thrown when <c>value</c> is <c>null</c>.</exception>
-  /// <example>
-  /// <code>
-  /// var roCrate = new ROCrate();
-  /// var rootDataset = new RootDataset(roCrate);
-  /// var person = new Person(roCrate, identifier: "Alice");
-  /// rootDataset.AppendTo("author", person);
-  /// </code>
-  /// </example>
-  public void AppendTo<T>(string key, T value) where T : Entity
-  {
-    if (key.StartsWith('@')) throw new Exception($"Cannot append to {key}");
-    if (value is null) throw new NullReferenceException("value cannot be null.");
-
-    var newItem = new Part { Id = value.GetCanonicalId() };
-    var itemList = new List<Part> { newItem };
-
-    if (Properties.TryGetPropertyValue(key, out var propsJson))
-    {
-      var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
-      if (currentItems.Count > 0 && !_containsPart(currentItems, newItem))
-        itemList.InsertRange(0, currentItems);
+        Id = Guid.NewGuid().ToString();
+        Properties = _empty();
     }
 
-    SetProperty(key, itemList);
-  }
-
-  private bool _containsPart(List<Part> parts, Part partToCheck)
-  {
-    foreach (var part in parts)
+    public Entity(ROCrate? crate = null, string? identifier = null, JsonObject? properties = null)
     {
-      if (partToCheck.Id == part.Id) return true;
+        RoCrate = crate;
+        Id = identifier ?? Guid.NewGuid().ToString();
+        Properties = _empty();
+        if (properties is not null) _unpackProperties(properties);
     }
 
-    return false;
-  }
+    public ROCrate? RoCrate { get; set; }
 
-  /// <summary>
-  /// Remove a property from the <c>Properties</c> field.
-  /// </summary>
-  /// <param name="propertyName"></param>
-  public void DeleteProperty(string propertyName)
-  {
-    Properties.Remove(propertyName);
-  }
+    public string Id { get; set; }
 
-  private protected JsonObject _empty()
-  {
-    var emptyJsonString = new Dictionary<string, string>
+    public JsonObject Properties { get; set; }
+
+    /// <summary>
+    /// Get the canonical ID of the crate that the entity is in.
+    /// </summary>
+    /// <returns></returns>
+    [Obsolete("GetCanonicalId is deprecated. Use Id property instead.")]
+    public string GetCanonicalId()
     {
-      { "@id", Id },
-      { "@type", DefaultType }
-    };
-    var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
-    return emptyObject;
-  }
-
-  private protected virtual string _formatIdentifier(string identifier)
-  {
-    return identifier;
-  }
-
-  private protected void _unpackProperties(JsonObject props)
-  {
-    using var propsEnumerator = props.GetEnumerator();
-    while (propsEnumerator.MoveNext())
-    {
-      var (key, value) = propsEnumerator.Current;
-      if (value != null) SetProperty(key, value);
+        return RoCrate.ResolveId(Id);
     }
-  }
 
-  /// <summary>
-  /// Convert <see cref="Entity"/> to JSON string.
-  /// </summary>
-  /// <returns>The <see cref="Entity"/> as a JSON string.</returns>
-  public virtual string Serialize()
-  {
-    var options = new JsonSerializerOptions
+    /// <summary>
+    /// Retrieve a property from <c>Properties</c> deserialsed as type <c>T</c>.
+    /// </summary>
+    /// <param name="propertyName">The name of the property to retrieve.</param>
+    /// <typeparam name="T">The type to deserialise the property into.</typeparam>
+    /// <returns>
+    /// <para>
+    /// The property as type <c>T</c> if the property exists, or <c>null</c> if the property does no exist on the entity.
+    /// </para>T
+    /// </returns>
+    public T? GetProperty<T>(string propertyName)
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<Entity>() }
-    };
-    var serialised = JsonSerializer.Serialize(this, options);
-    return serialised;
-  }
+        Properties.TryGetPropertyValue(propertyName, out var property);
+        var deserialisedProperty = property.Deserialize<T>();
+        return deserialisedProperty;
+    }
 
-  /// <summary>
-  /// Create an <see cref="Entity"/> from JSON properties.
-  /// </summary>
-  /// <param name="entityJson">The JSON representing the <see cref="Entity"/></param>
-  /// <param name="roCrate">The RO-Crate for the <see cref="Entity"/></param>
-  /// <returns>The deserialised <see cref="Entity"/></returns>
-  public static Entity? Deserialize(string entityJson, ROCrate roCrate)
-  {
-    var options = new JsonSerializerOptions
+    /// <summary>
+    /// Sersialise a property into the <c>Properties</c> field. This will update a property if it already exists.
+    /// </summary>
+    /// <param name="propertyName"></param>
+    /// <param name="property"></param>
+    /// <typeparam name="T"></typeparam>
+    public void SetProperty<T>(string propertyName, T property)
     {
-      WriteIndented = true,
-      Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-      Converters = { new EntityConverter<Entity>() }
-    };
-    var deserialized = JsonSerializer.Deserialize<Entity>(entityJson, options);
-    if (deserialized is not null) deserialized.RoCrate = roCrate;
-    return deserialized;
-  }
+        var serialisedProperty = JsonSerializer.SerializeToNode(property);
+        if (serialisedProperty != null)
+        {
+            // If a property already exists, remove first to avoid an exception, then add the new property
+            if (Properties.Remove(propertyName))
+            {
+                Properties.Add(propertyName, serialisedProperty);
+            }
+            else
+            {
+                Properties.Add(propertyName, serialisedProperty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Append a value to the entity's property.
+    /// </summary>
+    /// <param name="key">The element to append the value to.</param>
+    /// <param name="value">The value to be appended.</param>
+    /// <typeparam name="T">The type of <c>Entity</c> to be appended.</typeparam>
+    /// <exception cref="Exception">
+    /// Thrown when attempting to append to reserved key (those starting with '@').
+    /// </exception>
+    /// <exception cref="NullReferenceException">Thrown when <c>value</c> is <c>null</c>.</exception>
+    /// <example>
+    /// <code>
+    /// var roCrate = new ROCrate();
+    /// var rootDataset = new RootDataset(roCrate);
+    /// var person = new Person(roCrate, identifier: "Alice");
+    /// rootDataset.AppendTo("author", person);
+    /// </code>
+    /// </example>
+    public void AppendTo<T>(string key, T value) where T : Entity
+    {
+        if (key.StartsWith('@')) throw new Exception($"Cannot append to {key}");
+        if (value is null) throw new NullReferenceException("value cannot be null.");
+
+        var newItem = new Part { Id = value.Id };
+        var itemList = new List<Part> { newItem };
+
+        if (Properties.TryGetPropertyValue(key, out var propsJson))
+        {
+            var currentItems = propsJson.Deserialize<List<Part>>() ?? new List<Part>();
+            if (currentItems.Count > 0 && !_containsPart(currentItems, newItem))
+                itemList.InsertRange(0, currentItems);
+        }
+
+        SetProperty(key, itemList);
+    }
+
+    private bool _containsPart(List<Part> parts, Part partToCheck)
+    {
+        foreach (var part in parts)
+        {
+            if (partToCheck.Id == part.Id) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Remove a property from the <c>Properties</c> field.
+    /// </summary>
+    /// <param name="propertyName"></param>
+    public void DeleteProperty(string propertyName)
+    {
+        Properties.Remove(propertyName);
+    }
+
+    private protected JsonObject _empty()
+    {
+        var emptyJsonString = new Dictionary<string, string>
+        {
+            { "@id", Id },
+            { "@type", DefaultType }
+        };
+        var emptyObject = JsonSerializer.SerializeToNode(emptyJsonString).AsObject();
+        return emptyObject;
+    }
+
+    private protected virtual string _formatIdentifier(string identifier)
+    {
+        return identifier;
+    }
+
+    private protected void _unpackProperties(JsonObject props)
+    {
+        using var propsEnumerator = props.GetEnumerator();
+        while (propsEnumerator.MoveNext())
+        {
+            var (key, value) = propsEnumerator.Current;
+            if (value != null) SetProperty(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Convert <see cref="Entity"/> to JSON string.
+    /// </summary>
+    /// <returns>The <see cref="Entity"/> as a JSON string.</returns>
+    public virtual string Serialize()
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<Entity>() }
+        };
+        var serialised = JsonSerializer.Serialize(this, options);
+        return serialised;
+    }
+
+    /// <summary>
+    /// Create an <see cref="Entity"/> from JSON properties.
+    /// </summary>
+    /// <param name="entityJson">The JSON representing the <see cref="Entity"/></param>
+    /// <param name="roCrate">The RO-Crate for the <see cref="Entity"/></param>
+    /// <returns>The deserialised <see cref="Entity"/></returns>
+    public static Entity? Deserialize(string entityJson, ROCrate roCrate)
+    {
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            Converters = { new EntityConverter<Entity>() }
+        };
+        var deserialized = JsonSerializer.Deserialize<Entity>(entityJson, options);
+        if (deserialized is not null) deserialized.RoCrate = roCrate;
+        return deserialized;
+    }
 }

--- a/ROCrates.Net/ROCrate.cs
+++ b/ROCrates.Net/ROCrate.cs
@@ -61,6 +61,7 @@ public class ROCrate
     /// </summary>
     /// <param name="id">The ID to be resolved.</param>
     /// <returns>The resolved URI for the given ID.</returns>
+    [Obsolete("ResolveId is deprecated")]
     public string ResolveId(string id)
     {
         if (Uri.IsWellFormedUriString(id, UriKind.RelativeOrAbsolute)) return id;
@@ -87,7 +88,7 @@ public class ROCrate
         foreach (var entity in entities)
         {
             var entityType = entity.GetType();
-            var key = entity.GetCanonicalId();
+            var key = entity.Id;
             if (entityType == typeof(RootDataset))
             {
                 RootDataset = entity as RootDataset;

--- a/ROCrates.Net/ROCrate.cs
+++ b/ROCrates.Net/ROCrate.cs
@@ -91,7 +91,6 @@ public class ROCrate
             if (entityType == typeof(RootDataset))
             {
                 RootDataset = entity as RootDataset;
-                Entities.Remove(entity.Id);
             }
 
             else if (entityType == typeof(Metadata))
@@ -99,7 +98,6 @@ public class ROCrate
                 Metadata = entity as Metadata;
                 _dataEntities.Remove(Metadata);
                 _dataEntities.Add(entity as Metadata);
-                Entities.Remove(entity.Id);
             }
 
             else if (entityType == typeof(Preview))
@@ -107,15 +105,17 @@ public class ROCrate
                 Preview = entity as Preview;
                 _dataEntities.Remove(Preview);
                 _dataEntities.Add(entity as Preview);
-                Entities.Remove(entity.Id);
             }
 
             else if (entityType.IsSubclassOf(typeof(DataEntity)))
             {
                 if (!Entities.ContainsKey(key)) RootDataset.AppendTo("hasPart", entity);
+                _dataEntities.Remove(entity as DataEntity);
                 _dataEntities.Add(entity as DataEntity);
             }
 
+            Entities.Remove(entity.Id);
+            entity.RoCrate = this;
             Entities.Add(key, entity);
         }
     }

--- a/ROCrates.Net/ROCrates.Net.csproj
+++ b/ROCrates.Net/ROCrates.Net.csproj
@@ -8,7 +8,7 @@
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageTags>RO-Crate RO-Crates ro-crate ro-crates rocrate rocrates ROCrates ROCrates.Net</PackageTags>
         <PackageId>ROCrates.Net</PackageId>
-        <PackageVersion>0.1.2</PackageVersion>
+        <PackageVersion>0.1.3</PackageVersion>
         <Authors>Daniel Lea</Authors>
         <Company>Digital Research Service</Company>
         <RepositoryUrl>https://github.com/uon-drs/ROCrates.Net.git</RepositoryUrl>


### PR DESCRIPTION
## Overview

This patch fixes:
- `ROCrate.Add` throwing an error when overwriting an entity in the crate.
- Makes `Entity.GetCanonicalId` and `ROCrate.ResolveId` obsolete. Reference an entity's `Id` directly now.
- `ROCrate.Save` will save `Dataset`s and subclasses or `Dataset` first as these are directories that will need to exist before trying to dave their files.
- Remote `Dataset`s won't get a slash appended to their `@id` tags

## Notes

Version bump 0.1.2 -> 0.1.3
